### PR TITLE
fix: add scripts to start electron version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "private": true,
   "repository": "github:opengs/uashield",
   "scripts": {
+    "start:dev": "quasar dev -m electron",
+    "start:electron": "electron ./dist/electron/UnPackaged/electron-main.js",
+    "build:electron": "quasar build -m electron",
     "lint": "eslint --ext .js,.ts,.vue ./",
     "test": "echo \"No test specified\" && exit 0"
   },


### PR DESCRIPTION
Added scripts to start electron version (useful for macosx where executable version is not working)