### PR TITLE
i18n: Add spanish version app

### DIFF
--- a/src/components/LanguageSelect.vue
+++ b/src/components/LanguageSelect.vue
@@ -50,6 +50,11 @@ const languages : LanguageInterface[] = [
     symbol: 'en-US',
     icon: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABmJLR0QA/wD/AP+gvaeTAAABKklEQVQ4jcWQv0rDcBSFz/0laZqkAbVY8U9FrRRcRBAHhw6uPoIP0+fxCdwyFSfpaBAUG0GFxNKSNk2bxOQ6iJv1B+3gt5zpHL57gf+G2u3rnq6XmZmhKER5zvyTaZbSlXdzO6+cxjGpzfPTurm+qfT6n7g4MuC4U5zt63j0M7w9ezhoVffmDQxd1xcP3pA/xgVOdktw3ClazTK6XoIVU6CxVZGeIHZqFbINgfv3DMf1Eu56CQ43NAyiAi/+RDqghpOEtbTAmiXghzlqtoJBVEDXCLapyQ3GSUGzjKEpBH+UwygR+lEOZkBTxd9tIqiN8GlmvI4sBlAHEAffiQCoEAOSN6iXehCtblctqetvMEPiKEeAefE20fIGqt/pOMNudyGNNI5pWYHl+QJYo3QxhpvieAAAAABJRU5ErkJggg=='
   },
+    {
+    name: 'Español',
+    symbol: 'es-ES',
+    icon: ''
+  },
   {
     name: 'Polski',
     symbol: 'pl-PL',

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1,0 +1,18 @@
+export default {
+  language: 'Idioma',
+  ddos: {
+    description: 'Ataque DDOS que realiza muchas requests/solicitudes a targets de servidores enemigos. Los targets/objetivos comenzarán a funcionar mal o con lag.',
+    counter: {
+      atackedTimes: 'Número de ataques:',
+      currentTarget: 'Target/Objetivo actual: '
+    },
+    enable: {
+      name: 'Ataque DDOS',
+      description: 'Habilitar ataque DDOS en servidores críticos enemigos: gobierno, sistemas bancarios, webs de propaganda, ...'
+    },
+    proxy: {
+      name: 'Atacar sólo usando proxy',
+      description: 'Sin esta opción, el programa permitirá usar tu IP. Realizarás ataques más eficientes, pero los ataques no serán anónimos.'
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the translation to spanish for the app. I think the only remaining thing is to add the :es: icon.

Hope it's useful  :ukraine:  