### PR TITLE
Helm chart for quick deploy to Kubernetes

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -40,7 +40,7 @@ Targets being attacked are changed automatically and are downloaded from the con
 1. Build an image: `docker build . -t uashield`
 2. Run: `docker run uashield 512 true` - where `512` - threads count, and `true` | `false` if you want to use a proxy or not
 
-Or use pre-built version:
+Or use pre-built image:
 
 ```bash
 docker run -d ghcr.io/opengs/uashield:0.0.x 512 true

--- a/README-en.md
+++ b/README-en.md
@@ -40,7 +40,7 @@ Targets being attacked are changed automatically and are downloaded from the con
 1. Build an image: `docker build . -t uashield`
 2. Run: `docker run uashield 512 true` - where `512` - threads count, and `true` | `false` if you want to use a proxy or not
 
-Or use pre-built image:
+Or use [pre-built image](https://github.com/opengs/uashield/pkgs/container/uashield):
 
 ```bash
 docker run -d ghcr.io/opengs/uashield:0.0.x 512 true
@@ -57,7 +57,11 @@ docker run -d ghcr.io/opengs/uashield:0.0.x 512 true
 
 ## Deploy with Ansible
 
-[Readme](tools/ansible/README.md)
+[tools/ansible/README.md](tools/ansible/README.md)
+
+## Deploy to Kubernetes
+
+[tools/helm/README.md](tools/helm/README.md)
 
 ## Deploy with Play With Docker - free instance for 4 hours
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 1. Збірка імежду: `docker build . -t uashield`
 2. Запуск: `docker run uashield 500 true` - де `500` - кількість потоків, і `true` | `false` чи ви бажаєте використати проксі
 
-Або за допомогою вже зібраного імежду:
+Або за допомогою вже [зібраного імежду](https://github.com/opengs/uashield/pkgs/container/uashield):
 
 ```bash
 docker run -d ghcr.io/opengs/uashield:0.0.x 512 true
@@ -57,7 +57,11 @@ docker run -d ghcr.io/opengs/uashield:0.0.x 512 true
 
 ## Деплой за допомогою Ansible
 
-[Readme](tools/ansible/README.md)
+[tools/ansible/README.md](tools/ansible/README.md)
+
+## Деплой у Kubernetes
+
+[tools/helm/README.md](tools/helm/README.md)
 
 ## Деплой на Play With Docker - безкоштовний інстанс на 4 години
 

--- a/tools/helm/.helmignore
+++ b/tools/helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/tools/helm/Chart.yaml
+++ b/tools/helm/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: ua-cyber-shield
+description: UA Cyber SHIELD Helm chart
+
+type: application
+version: 1.0.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.9.0"

--- a/tools/helm/README.md
+++ b/tools/helm/README.md
@@ -1,0 +1,46 @@
+# UA Cyber SHIELD Helm chart
+
+This is a Helm chart for Kubernetes
+
+## Quick start
+
+### Prerequisites
+
+Make sure that you installed `helm` package on your local machine and you have connection to the Kubernetes cluster.
+
+### Install chart
+
+```bash
+cd tools/helm/
+helm install --create-namespace \
+    -n ua-cyber-shield \
+    -f values.yaml ua-cyber-shield .
+```
+
+### Upgrade chart
+
+```bash
+helm upgrade --install \
+    -n ua-cyber-shield \
+    -f values.yaml ua-cyber-shield .
+```
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| connections | int | `1000` |  |
+| fullnameOverride | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"alpine/bombardier"` |  |
+| image.tag | string | `"latest"` |  |
+| imagePullSecrets | list | `[]` |  |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| podAnnotations | object | `{}` |  |
+| podSecurityContext | object | `{}` |  |
+| replicaCount | int | `1` |  |
+| resources | object | `{}` |  |
+| securityContext | object | `{}` |  |
+| site | string | `""` |  |
+| tolerations | list | `[]` |  |

--- a/tools/helm/README.md
+++ b/tools/helm/README.md
@@ -29,11 +29,10 @@ helm upgrade --install \
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| connections | int | `1000` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"alpine/bombardier"` |  |
-| image.tag | string | `"latest"` |  |
+| image.repository | string | `"ghcr.io/opengs/uashield"` |  |
+| image.tag | string | `"0.0.x"` |  |
 | imagePullSecrets | list | `[]` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
@@ -42,5 +41,6 @@ helm upgrade --install \
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |
-| site | string | `""` |  |
+| threadsCount | int | `256` |  |
 | tolerations | list | `[]` |  |
+| useProxy | bool | `false` |  |

--- a/tools/helm/templates/_helpers.tpl
+++ b/tools/helm/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "uacybershield.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "uacybershield.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "uacybershield.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "uacybershield.labels" -}}
+helm.sh/chart: {{ include "uacybershield.chart" . }}
+{{ include "uacybershield.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "uacybershield.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "uacybershield.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "uacybershield.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "uacybershield.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/tools/helm/templates/deployment.yaml
+++ b/tools/helm/templates/deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "uacybershield.fullname" . }}
+  labels:
+    {{- include "uacybershield.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "uacybershield.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "uacybershield.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - {{ .Values.threadsCount | quote }}
+            - {{ .Values.useProxy | quote }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/tools/helm/values.yaml
+++ b/tools/helm/values.yaml
@@ -5,8 +5,8 @@
 # How many threads do we use?
 threadsCount: 256
 
-# Do we want to enable proxy?
-useProxy: true
+# Do we want to enable proxy? (true|false)
+useProxy: false
 
 # How many pods do we want to run?
 replicaCount: 1

--- a/tools/helm/values.yaml
+++ b/tools/helm/values.yaml
@@ -1,0 +1,41 @@
+# Default values for chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# How many threads do we use?
+threadsCount: 256
+
+# Do we want to enable proxy?
+useProxy: true
+
+# How many pods do we want to run?
+replicaCount: 1
+
+image:
+  repository: ghcr.io/opengs/uashield
+  pullPolicy: IfNotPresent
+  # You can a tag here: https://github.com/opengs/uashield/pkgs/container/uashield
+  tag: "0.0.x"
+
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 1
+  #   memory: 1Gi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+podAnnotations: {}
+podSecurityContext: {}
+securityContext: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
```
$ cd tools/helm
$ helm upgrade --install \
    -n ua-cyber-shield \
    -f values.yaml ua-cyber-shield .

$ kubectl get po
NAME                               READY   STATUS        RESTARTS   AGE
ua-cyber-shield-6b499ff9f9-f2gbp   1/1     Running       0          6s
ua-cyber-shield-6b499ff9f9-fc9zg   1/1     Running       0          4s
ua-cyber-shield-6b499ff9f9-vsb7k   1/1     Running       0          9s

$ kubectl logs -f ua-cyber-shield-6b499ff9f9-vsb7k
yarn run v1.22.17
$ NODE_ENV=production node --enable-source-maps ./build/headless/headless.js 256 false
Using 256 workers, proxy - false
...
Updating workers count to 0 => 256
...
Creating new worker..
...
https://xn--80aqakjqje5byf.xn--80adrabb4aegksdjbafk0u.xn--p1ai/ | DIRECT | 200
https://xn--80aafeah9bwaabcgldgz5p.xn--p1ai | ECONNABORTED
...
```

<img width="1081" alt="Screenshot 2022-03-03 at 11 40 05" src="https://user-images.githubusercontent.com/5184847/156538266-a398e0af-db0f-4a0e-a04a-bd3bad4ad046.png">
