### PR TITLE
Fix #54: Show version in title bar

### DIFF
--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -10,6 +10,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { configure } = require('quasar/wrappers')
 const NodePolyfillPlugin = require('node-polyfill-webpack-plugin')
+const { version } = require('./package.json')
 
 module.exports = configure(function (ctx) {
   return {
@@ -136,6 +137,10 @@ module.exports = configure(function (ctx) {
         ctx.prod ? 'compression' : '',
         'render' // keep this as last one
       ]
+    },
+
+    htmlVariables: {
+      version
     },
 
     // https://quasar.dev/quasar-cli/developing-pwa/configuring-pwa

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= productName %></title>
+    <title><%= productName %> v<%= version %></title>
 
     <meta charset="utf-8">
     <meta name="description" content="<%= productDescription %>">


### PR DESCRIPTION
Quick but clean addition of the current package.json version to the title bar.

Could be expanded later to store into Vuex so it's available throughout the code--but will wait and see if that's useful before adding!