### PR TITLE
Get stats from hosts

### DIFF
--- a/tools/ansible/README.md
+++ b/tools/ansible/README.md
@@ -48,6 +48,9 @@ Optional step, can be skipped
 
     ansible-playbook -u root deploy.yaml -i hosts
 
+### 7. Get stats of successful requests
+
+    ansible-playbook -u root stats.yaml -i hosts
 
 ## UA
 ### 1. Інсталюйте ansible на свою машину
@@ -90,3 +93,7 @@ ssh-agent bash -c "ssh-add /path/to/keys/*.pem"
 ### 6. Запустіть плейбук та введіть паролі, коли він запитає
 
     ansible-playbook -u root deploy.yaml -i hosts
+
+### 7. Перевірка статистики успішних запитів
+
+    ansible-playbook -u root stats.yaml -i hosts

--- a/tools/ansible/roles/stats/tasks/main.yml
+++ b/tools/ansible/roles/stats/tasks/main.yml
@@ -1,0 +1,6 @@
+- name: Get stats
+  shell: echo $(docker logs uashield | grep '| 200' -c)
+  register: echo_content
+
+- debug:
+    msg: "Hits {{ echo_content.stdout }} requests."

--- a/tools/ansible/stats.yaml
+++ b/tools/ansible/stats.yaml
@@ -1,0 +1,8 @@
+---
+- hosts: servers
+  become: yes
+  become_user: root
+  vars_files:
+    - vars/vars.yaml
+  roles:
+    - stats


### PR DESCRIPTION
Execute `ansible-playbook -u root stats.yaml -i hosts` and get stats of successful requests.

Example output:
```
TASK [stats : debug] *******************************************************************
ok: [x.x.x.x] => {
    "msg": "Hits '36877' requests."
}
ok: [x.x.x.x] => {
    "msg": "Hits '38999' requests."
}
```