### PR TITLE
docker-compose scaling fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,6 @@ services:
     uashield:
       build: .
       restart: always
-      container_name: uashield
-      image: uashield:latest
       environment:
         WORKERS: '256'
         USEPROXY: 'true'


### PR DESCRIPTION
## Description
There is `--scale` parameter in docker-compose ([docs](https://docs.docker.com/compose/reference/up/#:~:text=on%2Dcontainer%2Dexit.-,%2D%2Dscale%20SERVICE%3DNUM,-Scale%20SERVICE%20to)) that allows to start several instances of certain container. It's not working in current implementation.

Docker compose's `--scale` parameter is useful for running several container replicas in the same terminal window which is extremely handy for running on remote servers.

## Current behavior:

After running the following command:

```bash
docker-compose up --build --scale uashield=5
```

I'm getting the following error:

```
Recreating uashield_uashield_1 ... done
Recreating uashield_uashield_2 ... error

ERROR: for uashield_uashield_2  Cannot create container for service uashield: b'Conflict. The container name "/uashield" is already in use by container "853da05e2937124032ca3398b9dcd8d2b40ec4be3d5947ac8c1e7d21b1ee2409". You have to remove (or rename) that container to be able to reuse that name.'

ERROR: for uashield  Cannot create container for service uashield: b'Conflict. The container name "/uashield" is already in use by container "853da05e2937124032ca3398b9dcd8d2b40ec4be3d5947ac8c1e7d21b1ee2409". You have to remove (or rename) that container to be able to reuse that name.'
ERROR: Encountered errors while bringing up the project.
```

## Expected behavior

After running the following command:

```bash
docker-compose up --build --scale uashield=5
```

no errors need to be thrown. Containers need to be scaled to 5 running instances in parallel.

## Proposed solution

Now `scale` parameter does not respected by docker-compose because of strictly defined `container_name` and `image` properties in `uashield` service. Just removing them will resolve the problem and container names for replicas will not conflict with any other replicas. 
